### PR TITLE
Add `onClick` capability to LinkHeader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nebenan-components",
-  "version": "9.6.2",
+  "version": "9.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-components",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-components/issues",
-  "version": "9.6.2",
+  "version": "9.7.0",
   "files": [
     "images/*.svg",
     "images/*/*.svg",

--- a/preview/containers/content/index.jsx
+++ b/preview/containers/content/index.jsx
@@ -64,6 +64,7 @@ class Inputs extends PureComponent {
       'handleClipboardTextCopy',
       'handleAutocomplete',
       'handleTagsPickerSelect',
+      'handleLinkHeaderClick',
     );
 
     this.clipboardText = createRef();
@@ -95,6 +96,10 @@ class Inputs extends PureComponent {
     console.info('Got autocomplete input:', value);
     const autocompleteSuggestions = (value && value.length) ? value.split('') : [];
     this.setState({ suggestions: autocompleteSuggestions });
+  }
+
+  handleLinkHeaderClick() {
+    console.log('link header clicked');
   }
 
   render() {
@@ -169,6 +174,13 @@ class Inputs extends PureComponent {
           <LinkHeader to="/" reversed>
             <span className="ui-h3">Link Header</span>
             Content!
+          </LinkHeader>
+        </div>
+
+        <div className="preview-section">
+          <LinkHeader onClick={this.handleLinkHeaderClick} reversed>
+            <span className="ui-h3">Link Header</span>
+            Content with onClick handler!
           </LinkHeader>
         </div>
 

--- a/src/link_header/index.jsx
+++ b/src/link_header/index.jsx
@@ -41,7 +41,7 @@ const LinkHeader = ({
       </span>
     );
   }
-  return <Link {...cleanProps} {...{ to, className }}>{icon}{children}</Link>;
+  return <Link {...cleanProps} {...{ to, className, onClick }}>{icon}{children}</Link>;
 };
 
 LinkHeader.propTypes = {

--- a/src/link_header/index.jsx
+++ b/src/link_header/index.jsx
@@ -4,25 +4,50 @@ import clsx from 'clsx';
 import { Link } from 'react-router-dom';
 
 
-const LinkHeader = (props) => {
-  const { children, to, reversed, ...cleanProps } = props;
-  const className = clsx('c-link_header', props.className, {
+const LinkHeader = ({
+  children,
+  to,
+  onClick,
+  reversed,
+  className: passedClassName,
+  ...cleanProps
+}) => {
+  const isClickable = to || onClick;
+
+  const className = clsx('c-link_header', passedClassName, {
     'is-reversed': reversed,
+    'is-clickable': isClickable,
   });
 
-  if (!to) return <span {...cleanProps} className={className}>{children}</span>;
+  let icon;
+  if (isClickable) {
+    const iconClass = clsx({
+      'icon-arrow_right': !reversed,
+      'icon-arrow_left': reversed,
+    });
 
-  const iconClass = clsx({
-    'icon-arrow_right': !reversed,
-    'icon-arrow_left': reversed,
-  });
-  const icon = <i className={iconClass} />;
+    icon = <i className={iconClass} />;
+  }
+
+  if (!to) {
+    return (
+      <span
+        {...cleanProps}
+        onClick={onClick}
+        className={className}
+      >
+        {icon}
+        {children}
+      </span>
+    );
+  }
   return <Link {...cleanProps} {...{ to, className }}>{icon}{children}</Link>;
 };
 
 LinkHeader.propTypes = {
   className: PropTypes.string,
   to: PropTypes.string,
+  onClick: PropTypes.func,
   reversed: PropTypes.bool,
   children: PropTypes.node,
 };

--- a/src/link_header/index.scss
+++ b/src/link_header/index.scss
@@ -2,13 +2,14 @@
   padding-right: 25px;
   display: block;
   position: relative;
+  cursor: pointer;
 
   &.is-reversed {
     padding-right: 0;
     padding-left: 25px;
   }
 
-  @at-root a#{&} {
+  &.is-clickable {
     color: $color-gray-00;
   }
 


### PR DESCRIPTION
We need the `onClick` functionality in BizFE.

**Reason not to move this into goodhood:** This component needs a change in API in my opinion: It's somehow weird to have it tied to `Link` and forward props. Would rather have only the UI part or pass an `as` prop to decouple it from `Link`. If you take a look into the css code, you see overwrites to `.ui-hX' - not sure if we should keep those in.
