### PR TITLE
Add workaround for outside click issue in react 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nebenan-components",
-  "version": "9.7.0",
+  "version": "9.7.1-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-components",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-components/issues",
-  "version": "9.7.0",
+  "version": "9.7.1-beta.2",
   "files": [
     "images/*.svg",
     "images/*/*.svg",

--- a/src/context_menu/index.jsx
+++ b/src/context_menu/index.jsx
@@ -41,7 +41,7 @@ class ContextMenu extends PureComponent {
 
       document.addEventListener('click', this.handleGlobalClick);
       this.isListenerActive = true;
-    }, 1);
+    }, 0);
   }
 
   deactivate() {

--- a/src/context_menu/index.jsx
+++ b/src/context_menu/index.jsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 
 import keymanager from 'nebenan-helpers/lib/keymanager';
 import { bindTo } from 'nebenan-helpers/lib/utils';
+import { getReactRootElement } from './utils';
 
 
 class ContextMenu extends PureComponent {
@@ -29,25 +30,20 @@ class ContextMenu extends PureComponent {
   }
 
   activate() {
-    // # Workaround for event bubbling issue in react 17
-    // Prevents the following:
-    // - Some click handler calls ContextMenu.show()
-    // - ContextMenu attaches global click listener
-    // - Click event bubbles up from react root node to document
-    // - ContextMenu global click handler is called
-    setTimeout(() => {
-      if (this.isListenerActive) return;
-      this.stopListeningToKeys = keymanager('esc', this.hide);
+    if (this.isListenerActive) return;
+    this.stopListeningToKeys = keymanager('esc', this.hide);
 
-      document.addEventListener('click', this.handleGlobalClick);
-      this.isListenerActive = true;
-    }, 0);
+    getReactRootElement(document).addEventListener('click', this.handleGlobalClick);
+
+    this.isListenerActive = true;
   }
 
   deactivate() {
     if (!this.isListenerActive) return;
     this.stopListeningToKeys();
-    document.removeEventListener('click', this.handleGlobalClick);
+
+    getReactRootElement(document).removeEventListener('click', this.handleGlobalClick);
+
     this.isListenerActive = false;
   }
 

--- a/src/context_menu/index.jsx
+++ b/src/context_menu/index.jsx
@@ -29,10 +29,19 @@ class ContextMenu extends PureComponent {
   }
 
   activate() {
-    if (this.isListenerActive) return;
-    this.stopListeningToKeys = keymanager('esc', this.hide);
-    document.addEventListener('click', this.handleGlobalClick);
-    this.isListenerActive = true;
+    // # Workaround for event bubbling issue in react 17
+    // Prevents the following:
+    // - Some click handler calls ContextMenu.show()
+    // - ContextMenu attaches global click listener
+    // - Click event bubbles up from react root node to document
+    // - ContextMenu global click handler is called
+    setTimeout(() => {
+      if (this.isListenerActive) return;
+      this.stopListeningToKeys = keymanager('esc', this.hide);
+
+      document.addEventListener('click', this.handleGlobalClick);
+      this.isListenerActive = true;
+    }, 1);
   }
 
   deactivate() {

--- a/src/context_menu/utils.jsx
+++ b/src/context_menu/utils.jsx
@@ -1,0 +1,1 @@
+export const getReactRootElement = (document) => document.querySelector('#main');


### PR DESCRIPTION
https://github.com/mui-org/material-ui/issues/23215#issuecomment-716040637

> Click on the icon button, a DOM event (a.) is triggered.
> The event bubbles up to the React host.
> React bubbles the event on each React component.
> React calls the onClick handler on the icon button.
> React renders the ClickAwayListener.
> ClickAwayListener sets a listener on the document.
> The drawer opens.
> The same event (a.) keeps bubbling. It reaches the new listener set by the ClickAwayListener.
> The drawer closes.